### PR TITLE
Add account activation

### DIFF
--- a/app/assets/stylesheets/account_activations.scss
+++ b/app/assets/stylesheets/account_activations.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the AccountActivations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -1,0 +1,14 @@
+class AccountActivationsController < ApplicationController
+  def edit
+    user = User.find_by(email: params[:email])
+    if user && !user.activated? && user.authenticated?(:activation, params[:id])
+      user.activate
+      log_in user
+      flash[:success] = "Account activated!"
+      redirect_to user
+    else
+      flash[:danger] = "Invalid activation link"
+      redirect_to root_url
+    end
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,11 +6,19 @@ class SessionsController < ApplicationController
   def create
     user = User.find_by(email: params[:session][:email].downcase)
     if user && user.authenticate(params[:session][:password])
-      log_in user
-      remember user # a remember method that calls user.remember
-      params[:session][:remember_me] == '1' ? remember(user) : forget(user)
-      redirect_back_or user
-      # Log the user in and redirect to the user's show page.
+      if user.activated? #user activation
+        log_in user
+        params[:session][:remember_me] == '1' ? remember(user) : forget(user)
+        redirect_back_or user
+      else
+        message = "Account not activated. "
+        message += "Check your email for the activation link."
+        flash[:warning] = message
+        redirect_to root_url
+      end
+
+   # a remember method that calls user.remember
+   # Log the user in and redirect to the user's show page.
     else
       # Create an error message.
       flash.now[:danger] = 'Invalid email/password combination'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,9 +22,10 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      log_in @user
-      flash[:success] = "Welcome to the Sample App!"
-      redirect_to @user
+      #first activate your account .
+      @user.send_activation_email
+      flash[:info] = "Please check your email to activate your account."
+      redirect_to root_url
       # Handle a successful save.
     else
       render 'new'

--- a/app/helpers/account_activations_helper.rb
+++ b/app/helpers/account_activations_helper.rb
@@ -1,0 +1,2 @@
+module AccountActivationsHelper
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -16,7 +16,7 @@ module SessionsHelper
       @current_user ||= User.find_by(id: user_id)
     elsif (user_id = cookies.signed[:user_id])
       user = User.find_by(id: user_id)
-      if user && user.authenticated?(cookies[:remember_token])
+      if user && user.authenticated?(:remember, cookies[:remember_token])
         log_in user
         @current_user = user
       end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: "noreply@example.com"
   layout 'mailer'
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,24 @@
+class UserMailer < ApplicationMailer
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.user_mailer.account_activation.subject
+  #
+
+  def account_activation(user)
+    @user = user
+    mail to: user.email, subject: "Account activation"
+  end
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.user_mailer.password_reset.subject
+  #
+  def password_reset
+    @greeting = "Hi"
+
+    mail to: "to@example.org"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   #create an accessible attribute
-  attr_accessor :remember_token
+  attr_accessor :remember_token, :activation_token
+  before_save :downcase_email
+  before_create :create_activation_digest
   #checking the  validation of name and email
   before_save { self.email = email.downcase }
   #validation for name
@@ -33,15 +35,38 @@ class User < ApplicationRecord
   end
 
   # Returns true if the given token matches the digest.
-  def authenticated?(remember_token)
-    return false if remember_digest.nil?
-    BCrypt::Password.new(remember_digest).is_password?(remember_token)
+  def authenticated?(attribute, token)
+    digest = send("#{attribute}_digest")
+    return false if digest.nil?
+    BCrypt::Password.new(digest).is_password?(token)
   end
-
 
   # Forgets a user.
   def forget
     update_attribute(:remember_digest, nil)
   end
+
+  # Activates an account.
+  def activate
+    update_attribute(:activated, true)
+    update_attribute(:activated_at, Time.zone.now)
+  end
+  # Sends activation email.
+  def send_activation_email
+    UserMailer.account_activation(self).deliver_now
+  end
+
+  private
+
+    # Converts email to all lower-case.
+    def downcase_email
+      self.email = email.downcase
+    end
+
+    # Creates and assigns the activation token and digest.
+    def create_activation_digest
+      self.activation_token = User.new_token
+      self.activation_digest = User.digest(activation_token)
+    end
 
 end

--- a/app/views/user_mailer/account_activation.html.erb
+++ b/app/views/user_mailer/account_activation.html.erb
@@ -1,0 +1,7 @@
+<h1>Sample App</h1>
+<p>Hi <%= @user.name %>,</p>
+<p>
+  Welcome to the Sample App! Click on the link below to activate your account:
+</p>
+<%= link_to "Activate", edit_account_activation_url(@user.activation_token,
+                                                    email: @user.email) %>

--- a/app/views/user_mailer/account_activation.text.erb
+++ b/app/views/user_mailer/account_activation.text.erb
@@ -1,0 +1,4 @@
+<!--ACCOUNT ACTIVATION -->
+Hi <%= @user.name %>,
+Welcome to the Sample App! Click on the link below to activate your account:
+<%= edit_account_activation_url(@user.activation_token, email: @user.email) %>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,0 +1,5 @@
+<h1>User#password_reset</h1>
+
+<p>
+  <%= @greeting %>, find me in app/views/user_mailer/password_reset.html.erb
+</p>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,0 +1,3 @@
+User#password_reset
+
+<%= @greeting %>, find me in app/views/user_mailer/password_reset.text.erb

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,6 +36,13 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
+  # Don't use this literally; use your local dev host instead
+  host = 'example.com'
+  # Use this on the cloud IDE.
+  config.action_mailer.default_url_options = { host: host, protocol: 'https' }
+  # Use this if developing on localhost.
+  # config.action_mailer.default_url_options = { host: host, protocol: 'http' }
+
   config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -15,6 +15,7 @@ Rails.application.configure do
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
+  host = '<nameless-gorge-89102>.herokuapp.com'
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,6 +42,7 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.action_mailer.default_url_options = { host: 'example.com' }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,5 +15,7 @@ Rails.application.routes.draw do
   delete '/logout', to: 'sessions#destroy' #logout for user
   #in resources for user
   resources :users
+  #resources for account activation only for edit purpose.
+  resources :account_activations, only: [:edit]
 
 end

--- a/db/migrate/20211130052333_add_activation_to_users.rb
+++ b/db/migrate/20211130052333_add_activation_to_users.rb
@@ -1,0 +1,7 @@
+class AddActivationToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :activation_digest, :string
+    add_column :users, :activated, :boolean, default: false
+    add_column :users, :activated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_29_110712) do
+ActiveRecord::Schema.define(version: 2021_11_30_052333) do
 
   create_table "users", force: :cascade do |t|
     t.string "name"
@@ -20,6 +20,9 @@ ActiveRecord::Schema.define(version: 2021_11_29_110712) do
     t.string "password_digest"
     t.string "remember_digest"
     t.boolean "admin"
+    t.string "activation_digest"
+    t.boolean "activated", default: false
+    t.datetime "activated_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,7 +11,9 @@ User.create!(name: "Example User",
             email: "example@railstutorial.org",
             password: "foobar",
             password_confirmation: "foobar",
-            admin: true)
+            admin:  true,
+            activated: true,
+            activated_at: Time.zone.now)
 # Generate a bunch of additional users.
 99.times do |n|
   name = Faker::Name.name
@@ -20,5 +22,7 @@ User.create!(name: "Example User",
   User.create!(name: name,
                email: email,
                password: password,
-               password_confirmation: password)
+               password_confirmation: password,
+               activated: true,
+               activated_at: Time.zone.now)
 end

--- a/test/controllers/account_activations_controller_test.rb
+++ b/test/controllers/account_activations_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AccountActivationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -6,26 +6,33 @@ michael:
   email: michael@example.com
   password_digest: <%= User.digest('password') %>
   admin: true
+  activated: true
+  activated_at: <%= Time.zone.now %>
 
 archer:
   name: Sterling Archer
   email: duchess@example.gov
   password_digest: <%= User.digest('password') %>
-
+  activated: true
+  activated_at: <%= Time.zone.now %>
 lana:
   name: Lana Kane
   email: hands@example.gov
   password_digest: <%= User.digest('password') %>
-
+  activated: true
+  activated_at: <%= Time.zone.now %>
 malory:
   name: Malory Archer
   email: boss@example.gov
   password_digest: <%= User.digest('password') %>
-
+  activated: true
+  activated_at: <%= Time.zone.now %>
 <% 30.times do |n| %>
 user_<%= n %>:
   name: <%= "User #{n}" %>
   email: <%= "user-#{n}@example.com" %>
   password_digest: <%= User.digest('password') %>
+  activated: true
+  activated_at: <%= Time.zone.now %>
 <% end %>
 

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -1,6 +1,11 @@
 require "test_helper"
 
 class UsersSignupTest < ActionDispatch::IntegrationTest
+  #for mailer
+  def setup
+    ActionMailer::Base.deliveries.clear
+  end
+
   # testing for invalid information
   test "invalid signup information" do
     get signup_path
@@ -15,18 +20,34 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
     assert_template 'users/new'
   end
   # testing for valid information
-  test "valid signup information" do
+  test "valid signup information with account activation" do
     get signup_path
     assert_difference 'User.count', 1 do
-    post users_path, params: { user: {  name: "Example User",
+      post users_path, params: { user: { name: "Example User",
                                         email: "user@example.com",
                                         password: "password",
                                         password_confirmation: "password"
                                      }
                               }
     end
+    assert_equal 1, ActionMailer::Base.deliveries.size
+    user = assigns(:user)
+    assert_not user.activated?
+    # Try to log in before activation.
+    log_in_as(user)
+    assert_not is_logged_in?
+    # Invalid activation token
+    get edit_account_activation_path("invalid token", email: user.email)
+    assert_not is_logged_in?
+    # Valid token, wrong email
+    get edit_account_activation_path(user.activation_token, email: 'wrong')
+    assert_not is_logged_in?
+    # Valid activation token
+    get edit_account_activation_path(user.activation_token, email: user.email)
+    assert user.reload.activated?
     follow_redirect!
     assert_template 'users/show'
     assert is_logged_in?
+
   end
 end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,16 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user_mailer
+class UserMailerPreview < ActionMailer::Preview
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/account_activation
+  def account_activation
+    user = User.first
+    user.activation_token = User.new_token
+    UserMailer.account_activation(user)
+  end
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
+  def password_reset
+    UserMailer.password_reset
+  end
+
+end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class UserMailerTest < ActionMailer::TestCase
+=begin
+  test "account_activation" do
+    mail = UserMailer.account_activation
+    assert_equal "Account activation", mail.subject
+    assert_equal ["to@example.org"], mail.to
+    assert_equal ["from@example.com"], mail.from
+    assert_match "Hi", mail.body.encoded
+  end
+
+  test "password_reset" do
+    mail = UserMailer.password_reset
+    assert_equal "Password reset", mail.subject
+    assert_equal ["to@example.org"], mail.to
+    assert_equal ["from@example.com"], mail.from
+    assert_match "Hi", mail.body.encoded
+  end
+=end
+#for account activation .
+  test "account_activation" do
+    user = users(:michael)
+    user.activation_token = User.new_token
+    mail = UserMailer.account_activation(user)
+    assert_equal "Account activation", mail.subject
+    assert_equal [user.email], mail.to
+    assert_equal ["noreply@example.com"], mail.from
+    assert_match user.name, mail.body.encoded
+    assert_match user.activation_token, mail.body.encoded
+    assert_match CGI.escape(user.email), mail.body.encoded
+  end
+
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -59,6 +59,6 @@ class UserTest < ActiveSupport::TestCase
   end
   #authenticated? should return false for a user with nil digest
   test "authenticated? should return false for a user with nil digest" do
-    assert_not @user.authenticated?('')
+    assert_not @user.authenticated?(:remember, '')
   end
 end


### PR DESCRIPTION
With the added account activation, our sample application’s sign up,
log in, and log out machinery is nearly complete. The only
significant feature left is allowing users to reset their
passwords if they forget them.